### PR TITLE
[fixlib][fix] Fix Cryptography deprecation warning

### DIFF
--- a/fixlib/fixlib/core/ca.py
+++ b/fixlib/fixlib/core/ca.py
@@ -28,7 +28,7 @@ from tempfile import TemporaryDirectory
 from threading import Lock, Event, Thread, Condition
 from fixlib.logger import log
 from fixlib.event import add_event_listener, Event as FixEvent, EventType
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from jwt.exceptions import InvalidSignatureError
 
 
@@ -197,7 +197,7 @@ class TLSData:
                     for cert in (self.__ca_cert, self.__cert):
                         if (
                             isinstance(cert, Certificate)
-                            and cert.not_valid_after < datetime.utcnow() - self.renew_before
+                            and cert.not_valid_after_utc < datetime.now(timezone.utc) - self.renew_before
                         ):
                             self.reload()
                             break


### PR DESCRIPTION
# Description

Cryptography now prefers timezone aware datetimes. 

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
