### PR TITLE
[docker][feat] same downloads folder for core and shell

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,8 @@ services:
       - fixcore.runtime.start_collect_on_subscriber_connect=true
     restart: always
     stop_grace_period: 2m
+    volumes:
+      - ~/fixinventory-downloads:/home/fixinventory/downloads
   fixworker:
     image: somecr.io/someengineering/fixworker:edge
     container_name: fixworker


### PR DESCRIPTION
# Description

When a user schedules a job and writes to the download directory, it will have the same effect as executed from within the shell.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
