### PR TITLE
[core][fix] Fallback to BM25 sort order for fulltext searches when no…

### DIFF
--- a/fixcore/fixcore/cli/cli.py
+++ b/fixcore/fixcore/cli/cli.py
@@ -483,11 +483,15 @@ class CLIService(CLI, Service):
                 first_head_tail_in_a_row = None
                 head_tail_keep_order = True
 
-            # Define default sort order, if not already defined
-            # A sort order is required to always return the result in a deterministic way to the user.
-            # Deterministic order is required for head/tail to work
-            parts = [pt if pt.sort else evolve(pt, sort=default_sort) for pt in query.parts]
-            query = evolve(query, parts=parts)
+        # Define default sort order, if not already defined
+        # A sort order is required to always return the result in a deterministic way to the user.
+        # Deterministic order is required for head/tail to work
+        if query.is_simple_fulltext_search():
+            # Do not define any additional sort order for fulltext searches
+            # Fulltext searches are using the BM25 score as default sort order
+            default_sort = []
+        parts = [pt if pt.sort else evolve(pt, sort=default_sort) for pt in query.parts]
+        query = evolve(query, parts=parts)
 
         # If the last part is a navigation, we need to add sort which will ingest a new part.
         with_sort = query.set_sort(*default_sort) if query.current_part.navigation else query

--- a/fixcore/fixcore/query/model.py
+++ b/fixcore/fixcore/query/model.py
@@ -1029,7 +1029,7 @@ class Query:
         return self.__change_current_part(lambda p: evolve(p, tag=name))
 
     def is_simple_fulltext_search(self) -> bool:
-        return len(self.parts) == 1 and self.find_terms(lambda x: isinstance(x, FulltextTerm))
+        return len(self.parts) == 1 and len(self.find_terms(lambda x: isinstance(x, FulltextTerm))) == 1
 
     @property
     def current_part(self) -> Part:

--- a/fixcore/fixcore/query/model.py
+++ b/fixcore/fixcore/query/model.py
@@ -1028,6 +1028,9 @@ class Query:
     def tag(self, name: str) -> Query:
         return self.__change_current_part(lambda p: evolve(p, tag=name))
 
+    def is_simple_fulltext_search(self) -> bool:
+        return len(self.parts) == 1 and self.find_terms(lambda x: isinstance(x, FulltextTerm))
+
     @property
     def current_part(self) -> Part:
         # remember: the order of parts is reversed


### PR DESCRIPTION
… sort order is defined

# Description

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
