### PR TITLE
[ci][fix] Limit concurrent publish workflow runs on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   edge:
     name: Update edge docs


### PR DESCRIPTION
# Description

Workflow runs don't necessarily complete in the order that they were submitted, which is problematic when created PRs are overwritten with data generated from an earlier commit.

For the publish workflow, we only care about the latest commit to main, so any currently running jobs can and should be canceled.

**Note:** Due to the defined concurrency group, tagged releases will not be terminated.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
