### PR TITLE
[aws][fix]: Fix query stat for cloudwatch metric requests

### DIFF
--- a/plugins/aws/fix_plugin_aws/resource/base.py
+++ b/plugins/aws/fix_plugin_aws/resource/base.py
@@ -207,7 +207,9 @@ class AwsResource(BaseResource, ABC):
                     try:
                         cls.collect_usage_metrics(builder)
                     except Exception as e:
-                        log.warning(f"Failed to collect usage metrics for {cls.__name__}: {e}")
+                        log.warning(
+                            f"Failed to collect usage metrics for {cls.__name__} in region {builder.region.id}: {e}"
+                        )
             except Boto3Error as e:
                 msg = f"Error while collecting {cls.__name__} in region {builder.region.name}: {e}"
                 builder.core_feedback.error(msg, log)

--- a/plugins/aws/fix_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/fix_plugin_aws/resource/cloudwatch.py
@@ -527,7 +527,7 @@ class AwsCloudwatchMetricData:
                     if metric is not None and metric_id is not None:
                         result[lookup[metric_id]] = metric
             except Exception as e:
-                log.error(f"An error occurred while processing a metric query: {e}")
+                log.warning(f"An error occurred while processing a metric query: {e}")
                 raise e
 
         return result
@@ -570,11 +570,15 @@ def update_resource_metrics(
             continue
 
         for metric_value, maybe_stat_name in normalizer.compute_stats(metric.metric_values):
-            name = normalizer.metric_name + "_" + normalizer.unit
-            value = normalizer.normalize_value(metric_value)
-            stat_name = str(maybe_stat_name or normalizer.stat_map[query.stat])
+            try:
+                name = normalizer.metric_name + "_" + normalizer.unit
+                value = normalizer.normalize_value(metric_value)
+                stat_name = str(maybe_stat_name or normalizer.stat_map[query.stat])
 
-            resource._resource_usage[name][stat_name] = value
+                resource._resource_usage[name][stat_name] = value
+            except KeyError as e:
+                log.warning(f"An error occured while setting metric values: {e}")
+                raise
 
 
 def bytes_to_megabits_per_second(bytes: float, period: timedelta) -> float:

--- a/plugins/aws/fix_plugin_aws/resource/ec2.py
+++ b/plugins/aws/fix_plugin_aws/resource/ec2.py
@@ -696,9 +696,13 @@ class AwsEc2Volume(EC2Taggable, AwsResource, BaseVolume):
                 normalize_value=partial(operations_to_iops, period=five_minutes_or_less),
             ),
             "VolumeTotalWriteTime": MetricNormalization(
-                metric_name=MetricName.VolumeTotalWriteTime, unit=MetricUnit.Seconds
+                metric_name=MetricName.VolumeTotalWriteTime,
+                unit=MetricUnit.Seconds,
+                compute_stats=calculate_min_max_avg,
             ),
-            "VolumeIdleTime": MetricNormalization(metric_name=MetricName.VolumeIdleTime, unit=MetricUnit.Seconds),
+            "VolumeIdleTime": MetricNormalization(
+                metric_name=MetricName.VolumeIdleTime, unit=MetricUnit.Seconds, compute_stats=calculate_min_max_avg
+            ),
             "VolumeQueueLength": MetricNormalization(metric_name=MetricName.VolumeQueueLength, unit=MetricUnit.Count),
         }
 

--- a/plugins/aws/fix_plugin_aws/resource/elbv2.py
+++ b/plugins/aws/fix_plugin_aws/resource/elbv2.py
@@ -813,7 +813,7 @@ class AwsAlbTargetGroup(ElbV2Taggable, AwsResource):
                         namespace="AWS/ApplicationELB",
                         period=delta,
                         ref_id=tg_id,
-                        stat="Min",  # since it reports the number of AZ that meets requirements, we're only interested in the min (max is constant and equals to the number of AZs) # noqa
+                        stat="Minimum",  # since it reports the number of AZ that meets requirements, we're only interested in the min (max is constant and equals to the number of AZs) # noqa
                         unit="Count",
                         LoadBalancer=lb_arn_id,
                         TargetGroup=tg_arn_id,


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.
- [x] Fix `WARNING|Failed to collect usage metrics for AwsEc2Volume: 'Sum'` error
- [x] Fix `WARNING|An AWS API error ValidationError occurred: The value Min for parameter MetricDataQueries` error

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
