### PR TITLE
[fixinventory][feat] Add ability to specify max number of resources per account

### DIFF
--- a/fixlib/test/test_graph.py
+++ b/fixlib/test/test_graph.py
@@ -1,7 +1,7 @@
 from platform import python_implementation
 
 import pytest
-from fixlib.graph import Graph, GraphExportIterator, EdgeKey
+from fixlib.graph import Graph, GraphExportIterator, EdgeKey, MaxNodesExceeded
 from fixlib.baseresources import BaseResource, EdgeType, GraphRoot
 import fixlib.logger as logger
 from attrs import define
@@ -128,3 +128,14 @@ def test_find_cycles():
         EdgeKey(edge_type=EdgeType.default, src=n1, dst=n2),
         EdgeKey(edge_type=EdgeType.default, src=n2, dst=n1),
     ]
+
+
+def test_graph_max_nodes():
+    g = Graph(max_nodes=5)
+
+    for i in range(5):
+        g.add_node(SomeTestResource(id=f"node{i}", tags={}))
+    assert len(g.nodes) == 5
+
+    with pytest.raises(MaxNodesExceeded):
+        g.add_node(SomeTestResource(id="node6", tags={}))

--- a/fixworker/fixworker/config.py
+++ b/fixworker/fixworker/config.py
@@ -68,6 +68,9 @@ class FixWorkerConfig:
     )
     debug_dump_json: bool = field(default=False, metadata={"description": "Dump the generated JSON data to disk"})
     tempdir: Optional[str] = field(default=None, metadata={"description": "Directory to create temporary files in"})
+    max_resources_per_account: Optional[int] = field(
+        default=None, metadata={"description": "Maximum number of resources per account"}
+    )
     cleanup: bool = field(default=False, metadata={"description": "Enable cleanup of resources"})
     cleanup_pool_size: int = field(
         factory=lambda: num_default_threads() * 2,

--- a/fixworker/test/test_collect.py
+++ b/fixworker/test/test_collect.py
@@ -74,6 +74,7 @@ def test_collect_and_send() -> None:
                     "debug_dump_json": False,
                     "graph_merge_kind": GraphMergeKind.cloud,
                     "graph_sender_pool_size": 5,
+                    "max_resources_per_account": None,
                     "timeout": 10800,
                     "tempdir": None,
                 },

--- a/plugins/aws/fix_plugin_aws/collector.py
+++ b/plugins/aws/fix_plugin_aws/collector.py
@@ -144,6 +144,7 @@ class AwsAccountCollector:
         regions: List[str],
         core_feedback: CoreFeedback,
         task_data: Json,
+        max_resources_per_account: Optional[int] = None,
     ) -> None:
         self.config = config
         self.cloud = cloud
@@ -153,7 +154,7 @@ class AwsAccountCollector:
             id=global_region_by_partition(account.partition), tags={}, name="global", account=account
         )
         self.regions = [AwsRegion(id=region, tags={}, account=account) for region in regions]
-        self.graph = Graph(root=self.account)
+        self.graph = Graph(root=self.account, max_nodes=max_resources_per_account)
         self.error_accumulator = ErrorAccumulator()
         self.client = AwsClient(
             config,

--- a/plugins/azure/fix_plugin_azure/__init__.py
+++ b/plugins/azure/fix_plugin_azure/__init__.py
@@ -14,7 +14,7 @@ from fixlib.baseresources import Cloud
 from fixlib.config import Config
 from fixlib.core.actions import CoreFeedback
 from fixlib.core.progress import ProgressTree, ProgressDone
-from fixlib.graph import Graph
+from fixlib.graph import Graph, MaxNodesExceeded
 from fixlib.proc import collector_initializer
 from fixlib.types import Json
 
@@ -74,22 +74,27 @@ class AzureCollectorPlugin(BaseCollectorPlugin):
 
         # Collect all subscriptions
         with ProcessPoolExecutor(max_workers=config.subscription_pool_size) as executor:
-            wait_for = [executor.submit(collect_in_process, sub, self.task_data) for sub in args]
+            wait_for = [
+                executor.submit(collect_in_process, sub, self.task_data, self.max_resources_per_account) for sub in args
+            ]
             for future in as_completed(wait_for):
                 subscription, graph = future.result()
                 progress.add_progress(ProgressDone(subscription.subscription_id, 1, 1, path=[cloud.id]))
                 if not isinstance(graph, Graph):
                     log.debug(f"Skipping subscription graph of invalid type {type(graph)}")
                     continue
-                self.send_account_graph(graph)
+                try:
+                    self.send_account_graph(graph)
+                except MaxNodesExceeded as e:
+                    self.core_feedback.error(f"Max resources exceeded: {e}", log)
                 del graph
 
 
-def collect_account_proxy(subscription_collector_arg: AzureSubscriptionArg, queue: multiprocessing.Queue) -> None:  # type: ignore
+def collect_account_proxy(subscription_collector_arg: AzureSubscriptionArg, queue: multiprocessing.Queue, max_resources_per_account: Optional[int] = None) -> None:  # type: ignore
     collector_initializer()
     config, cloud, subscription, account_config, core_feedback, task_data = subscription_collector_arg
     subscription_collector = AzureSubscriptionCollector(
-        config, cloud, subscription, account_config.credentials(), core_feedback, task_data
+        config, cloud, subscription, account_config.credentials(), core_feedback, task_data, max_resources_per_account
     )
     try:
         subscription_collector.collect()
@@ -100,12 +105,19 @@ def collect_account_proxy(subscription_collector_arg: AzureSubscriptionArg, queu
 
 
 def collect_in_process(
-    subscription_collector_arg: AzureSubscriptionArg, task_data: Optional[Json]
+    subscription_collector_arg: AzureSubscriptionArg,
+    task_data: Optional[Json],
+    max_resources_per_account: Optional[int] = None,
 ) -> Tuple[AzureSubscription, Graph]:
     ctx = multiprocessing.get_context("spawn")
     queue = ctx.Queue()
     process = ctx.Process(
-        target=collect_account_proxy, kwargs={"subscription_collector_arg": subscription_collector_arg, "queue": queue}
+        target=collect_account_proxy,
+        kwargs={
+            "subscription_collector_arg": subscription_collector_arg,
+            "queue": queue,
+            "max_resources_per_account": max_resources_per_account,
+        },
     )
     process.start()
     result = queue.get()

--- a/plugins/azure/fix_plugin_azure/__init__.py
+++ b/plugins/azure/fix_plugin_azure/__init__.py
@@ -16,7 +16,6 @@ from fixlib.core.actions import CoreFeedback
 from fixlib.core.progress import ProgressTree, ProgressDone
 from fixlib.graph import Graph, MaxNodesExceeded
 from fixlib.proc import collector_initializer
-from fixlib.types import Json
 
 log = logging.getLogger("fix.plugin.azure")
 
@@ -74,9 +73,7 @@ class AzureCollectorPlugin(BaseCollectorPlugin):
 
         # Collect all subscriptions
         with ProcessPoolExecutor(max_workers=config.subscription_pool_size) as executor:
-            wait_for = [
-                executor.submit(collect_in_process, sub, self.task_data, self.max_resources_per_account) for sub in args
-            ]
+            wait_for = [executor.submit(collect_in_process, sub, self.max_resources_per_account) for sub in args]
             for future in as_completed(wait_for):
                 subscription, graph = future.result()
                 progress.add_progress(ProgressDone(subscription.subscription_id, 1, 1, path=[cloud.id]))
@@ -106,7 +103,6 @@ def collect_account_proxy(subscription_collector_arg: AzureSubscriptionArg, queu
 
 def collect_in_process(
     subscription_collector_arg: AzureSubscriptionArg,
-    task_data: Optional[Json],
     max_resources_per_account: Optional[int] = None,
 ) -> Tuple[AzureSubscription, Graph]:
     ctx = multiprocessing.get_context("spawn")

--- a/plugins/azure/fix_plugin_azure/collector.py
+++ b/plugins/azure/fix_plugin_azure/collector.py
@@ -59,13 +59,14 @@ class AzureSubscriptionCollector:
         credentials: AzureCredentials,
         core_feedback: CoreFeedback,
         task_data: Optional[Json] = None,
+        max_resources_per_account: Optional[int] = None,
     ):
         self.config = config
         self.cloud = cloud
         self.subscription = subscription
         self.credentials = credentials
         self.core_feedback = core_feedback
-        self.graph = Graph(root=subscription)
+        self.graph = Graph(root=subscription, max_nodes=max_resources_per_account)
         self.task_data = task_data
 
     def collect(self) -> None:

--- a/plugins/digitalocean/fix_plugin_digitalocean/collector.py
+++ b/plugins/digitalocean/fix_plugin_digitalocean/collector.py
@@ -177,10 +177,17 @@ class DigitalOceanTeamCollector:
     all DigitalOcean resources
     """
 
-    def __init__(self, team: DigitalOceanTeam, client: StreamingWrapper, last_run_started_at: datetime) -> None:
+    def __init__(
+        self,
+        team: DigitalOceanTeam,
+        client: StreamingWrapper,
+        last_run_started_at: datetime,
+        max_resources_per_account: Optional[int] = None,
+    ) -> None:
         self.client = client
         self.team = team
         self.last_run_started_at = last_run_started_at
+        self.max_resources_per_account = max_resources_per_account
 
         # Mandatory collectors are always collected regardless of whether
         # they were included by --do-collect or excluded by --do-no-collect
@@ -225,7 +232,7 @@ class DigitalOceanTeamCollector:
         """
         log.info("Collecting DigitalOcean resources for team %s", self.team.id)
 
-        self.graph = Graph(root=self.team)
+        self.graph = Graph(root=self.team, max_nodes=self.max_resources_per_account)
         collectors = set(self.collector_set)
 
         log.debug((f"Running the following collectors in {self.team.rtdname}:" f" {', '.join(collectors)}"))

--- a/plugins/gcp/fix_plugin_gcp/collector.py
+++ b/plugins/gcp/fix_plugin_gcp/collector.py
@@ -34,12 +34,19 @@ def called_mutator_apis() -> List[GcpApiSpec]:
 
 
 class GcpProjectCollector:
-    def __init__(self, config: GcpConfig, cloud: Cloud, project: GcpProject, core_feedback: CoreFeedback) -> None:
+    def __init__(
+        self,
+        config: GcpConfig,
+        cloud: Cloud,
+        project: GcpProject,
+        core_feedback: CoreFeedback,
+        max_resources_per_account: Optional[int] = None,
+    ) -> None:
         self.config = config
         self.cloud = cloud
         self.project = project
         self.core_feedback = core_feedback
-        self.graph = Graph(root=self.project)
+        self.graph = Graph(root=self.project, max_nodes=max_resources_per_account)
         self.credentials = Credentials.get(self.project.id)
 
     def collect(self) -> None:


### PR DESCRIPTION
# Description

This adds a config property `fixworker.max_resources_per_account` which defaults to `None`.
It also adds a `max_nodes` property to the `fixlib.graph.Graph` class. If the number of max nodes is exceeded during an `add_node()` operation a `MaxNodesExceeded` exception is thrown.

`BaseCollectorPlugin` now has a `max_resources_per_account` property. In `send_account_graph()`, the method that sends a plugin's account graph to the core (if `merge_kind = account`) or merges it into the global graph (if `merge_kind = cloud`) a check is performed to see whether the number of nodes in the account graph exceeds the max configured. If yes, the account graph is discarded. This acts as a safety net in case the collector plugin messes up.

Ideally a too large account graph should never reach the `send_account_graph()` method though and already explode before exceeding `max_resources_per_account`. This is implemented in each collector plugin, by setting  `Graph(max_nodes=max_resources_per_account)` on each account's graph object. This way an exception is thrown on `add_node`/`add_resource` as soon as the the first node exceeds the max.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
