### PR TITLE
[core][fix] Treat optional config properties as such

### DIFF
--- a/fixcore/fixcore/core_config.py
+++ b/fixcore/fixcore/core_config.py
@@ -669,7 +669,7 @@ class EditableConfig(ConfigObject):
 
 def config_model() -> List[Json]:
     config_classes = {EditableConfig, CustomCommandsConfig}
-    return dataclasses_to_fixcore_model(config_classes, use_optional_as_required=True)
+    return dataclasses_to_fixcore_model(config_classes)
 
 
 # Define rules to validate this config


### PR DESCRIPTION
# Description

Properties marked as optional are handled as required in the configuration.
This leads to issues with custom commands.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
