### PR TITLE
[core][feat] TimeSeries: allow defining a factor for computing the average

### DIFF
--- a/fixcore/fixcore/cli/command.py
+++ b/fixcore/fixcore/cli/command.py
@@ -6186,9 +6186,9 @@ class DbCommand(CLICommand, PreserveOutputFormat):
 class TimeSeriesCommand(CLICommand):
     """
     ```
-    timeseries snapshot --name <time series> <aggregate search>
+    timeseries snapshot --name <time series> [--avg-factor <factor>] <aggregate search>
     timeseries get --name <time series> --start <time> --end <time> --granularity <duration|integer>
-                   --group <group> --filter <var><op><value>
+                   --group <group> --filter <var><op><value> --avg-factor <factor>
     timeseries list
     timeseries downsample
     ```
@@ -6219,7 +6219,8 @@ class TimeSeriesCommand(CLICommand):
     - `--group` - The variable(s) to select in the group. Can be repeated multiple times.
     - `--filter` - The variable(s) to filter. Can be repeated multiple times.
     - `--granularity` - The granularity of the time series. Can be a duration or an integer.
-
+    - `--avg-factor` - Factor used to divide values to compute the average.
+                       This is required for very big numbers to avoid overflow.
 
     ## Examples
 
@@ -6250,6 +6251,7 @@ class TimeSeriesCommand(CLICommand):
             "list": [],
             "snapshot": [
                 ArgInfo("--name", help_text="<time series>."),
+                ArgInfo("--avg-factor", help_text="<avg factor>."),
                 ArgInfo(expects_value=True, value_hint="search"),
             ],
             "get": [
@@ -6260,6 +6262,7 @@ class TimeSeriesCommand(CLICommand):
                 ArgInfo("--filter", expects_value=True, can_occur_multiple_times=True, help_text="<var><op><value>"),
                 ArgInfo("--granularity", expects_value=True, help_text="<duration|integer>"),
                 ArgInfo("--aggregation", expects_value=True, possible_values=["avg", "sum", "min", "max"]),
+                ArgInfo("--avg-factor", help_text="<avg factor>."),
             ],
             "downsample": [],
         }
@@ -6268,13 +6271,16 @@ class TimeSeriesCommand(CLICommand):
         async def snapshot_time_series(part: str) -> AsyncIterator[str]:
             parser = NoExitArgumentParser()
             parser.add_argument("--name", type=str, required=True)
+            parser.add_argument("--avg-factor", type=int)
             parsed, rest = parser.parse_known_args(args_parts_parser.parse(part))
             graph_name = ctx.graph_name
             graph_db = self.dependencies.db_access.get_graph_db(graph_name)
             model = await self.dependencies.model_handler.load_model(graph_name)
             query = await self.dependencies.template_expander.parse_query(" ".join(rest), ctx.section, env=ctx.env)
             query_model = QueryModel(query, model, ctx.env)
-            res = await self.dependencies.db_access.time_series_db.add_entries(parsed.name, query_model, graph_db)
+            res = await self.dependencies.db_access.time_series_db.add_entries(
+                parsed.name, query_model, graph_db, avg_factor=parsed.avg_factor
+            )
             yield f"{res} entries added to time series {parsed.name}."
 
         async def load_time_series(part: str) -> Tuple[CLISourceContext, AsyncIterator[Json]]:
@@ -6292,6 +6298,7 @@ class TimeSeriesCommand(CLICommand):
             parser.add_argument("--filter", type=predicate_term.parse, nargs="*", default=None)
             parser.add_argument("--granularity", type=parse_duration_or_int, default=5)
             parser.add_argument("--aggregation", choices=["avg", "sum", "min", "max"], default="avg")
+            parser.add_argument("--avg-factor", type=int)
             p = parser.parse_args(args_parts_unquoted_parser.parse(part))
             timeout = if_set(ctx.env.get("search_timeout"), duration)
             cursor = await self.dependencies.db_access.time_series_db.load_time_series(
@@ -6303,6 +6310,7 @@ class TimeSeriesCommand(CLICommand):
                 granularity=p.granularity,
                 timeout=timeout,
                 aggregation=p.aggregation,
+                avg_factor=p.avg_factor,
             )
             return CLISourceContext(cursor.count(), cursor.full_count(), cursor.stats()), cursor
 

--- a/fixcore/fixcore/db/arango_query.py
+++ b/fixcore/fixcore/db/arango_query.py
@@ -892,7 +892,7 @@ def load_time_series(
     # slot the time by averaging each single group
     query += f" LET {time_slot} = (FLOOR(d.at / @{gran}) * @{gran}) + @{ctx.add_bind_var(offset)}"
     query += f" COLLECT group_slot={time_slot}, complete_group=d.group"
-    if avg_factor:
+    if avg_factor:  # Required as long as https://github.com/arangodb/arangodb/issues/21096 is not fixed
         assert avg_factor > 0, "Given average factor must be greater than 0!"
         bvf = ctx.add_bind_var(avg_factor)
         query += f" AGGREGATE slot_avg = AVG(d.v / @{bvf})"

--- a/fixcore/tests/fixcore/db/arango_query_test.py
+++ b/fixcore/tests/fixcore/db/arango_query_test.py
@@ -367,3 +367,7 @@ def test_load_time_series() -> None:
         "SORT group_slot RETURN {at: group_slot,group: { a: group_a, b: group_b }, v: agg_val}"
     )
     assert bv == {"b0": "foo", "b1": 1699913600, "b2": 1700000000, "b3": "a", "b4": 3600, "b5": 800}
+    # use avg-factor
+    q, _ = load_time_series("ts", "foo", now - (24 * one_hour), now, one_hour, avg_factor=1000)
+    assert "slot_avg = AVG(d.v / @b" in q  # factor divides average
+    assert "v: slot_avg * @b" in q  # factor multiplies result

--- a/fixcore/tests/fixcore/db/timeseriesdb_test.py
+++ b/fixcore/tests/fixcore/db/timeseriesdb_test.py
@@ -49,6 +49,8 @@ async def test_create_time_series(timeseries_db: TimeSeriesDB, foo_model: Model,
     ## check filter_by is working
     # some_int is the same for all entries: one every hour: 5 entries
     assert len(await load_ts(name="test", start=begin, end=after5h, filter_by=[(P("id").eq("1"))])) == 5
+    # avg factor does not change the result size
+    assert len(await load_ts(name="test", start=begin, end=after5h, filter_by=[(P("id").eq("1"))], avg_factor=10)) == 5
 
 
 async def test_compact_time_series(timeseries_db: TimeSeriesDB, foo_model: Model, filled_graph_db: GraphDB) -> None:


### PR DESCRIPTION
# Description

Computing the average with big numbers can lead to an overflow in ArangoDB.
This PR applies a factor to all values before the avg is computed.

Related issue is this: https://github.com/arangodb/arangodb/issues/21096
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
