### PR TITLE
[azure][fix]: Reimplemented fleet and clusters connection

### DIFF
--- a/plugins/azure/fix_plugin_azure/resource/containerservice.py
+++ b/plugins/azure/fix_plugin_azure/resource/containerservice.py
@@ -128,18 +128,14 @@ class AzureFleet(MicrosoftResource):
             items: List[Json] = graph_builder.client.list(api_spec)
             if not items:
                 return
-            item: Json = next(iter(items), {})
-
-            try:
-                self.cluster_resource_id = item["properties"]["clusterResourceId"]
-            except KeyError as e:
-                log.warning(f"An error occured while setting cluster_resource_id: {e}")
+            for item in items:
+                try:
+                    cluster_id = item["properties"]["clusterResourceId"]
+                    graph_builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureManagedCluster, id=cluster_id)
+                except KeyError as e:
+                    log.warning(f"An error occured while setting cluster_resource_id: {e}")
 
         graph_builder.submit_work(service, collect_fleets)
-
-    def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if cluster_id := self.cluster_resource_id:
-            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureManagedCluster, id=cluster_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/fix_plugin_azure/resource/containerservice.py
+++ b/plugins/azure/fix_plugin_azure/resource/containerservice.py
@@ -112,6 +112,9 @@ class AzureFleet(MicrosoftResource):
     hub_profile: Optional[AzureFleetHubProfile] = field(default=None, metadata={'description': 'The FleetHubProfile configures the fleet hub.'})  # fmt: skip
     azure_fleet_identity: Optional[AzureManagedServiceIdentity] = field(default=None, metadata={'description': 'Managed service identity (system assigned and/or user assigned identities)'})  # fmt: skip
     resource_group: Optional[str] = field(default=None, metadata={"description": "Resource group name"})
+    _cluster_resource_ids: Optional[List[str]] = field(
+        default=None, metadata={"description": "Reference to the cluster IDs"}
+    )
 
     def post_process(self, graph_builder: GraphBuilder, source: Json) -> None:
         def collect_fleets() -> None:
@@ -127,14 +130,17 @@ class AzureFleet(MicrosoftResource):
             items: List[Json] = graph_builder.client.list(api_spec)
             if not items:
                 return
-            for item in items:
-                try:
-                    cluster_id = item["properties"]["clusterResourceId"]
-                    graph_builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureManagedCluster, id=cluster_id)
-                except KeyError as e:
-                    log.warning(f"An error occured while taking cluster id: {e}")
+            try:
+                self._cluster_resource_ids = [item["properties"]["clusterResourceId"] for item in items]
+            except KeyError as e:
+                log.warning(f"An error occured while taking cluster id: {e}")
 
         graph_builder.submit_work(service, collect_fleets)
+
+    def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
+        if cluster_ids := self._cluster_resource_ids:
+            for cluster_id in cluster_ids:
+                builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureManagedCluster, id=cluster_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/fix_plugin_azure/resource/containerservice.py
+++ b/plugins/azure/fix_plugin_azure/resource/containerservice.py
@@ -112,7 +112,6 @@ class AzureFleet(MicrosoftResource):
     hub_profile: Optional[AzureFleetHubProfile] = field(default=None, metadata={'description': 'The FleetHubProfile configures the fleet hub.'})  # fmt: skip
     azure_fleet_identity: Optional[AzureManagedServiceIdentity] = field(default=None, metadata={'description': 'Managed service identity (system assigned and/or user assigned identities)'})  # fmt: skip
     resource_group: Optional[str] = field(default=None, metadata={"description": "Resource group name"})
-    cluster_resource_id: Optional[str] = field(default=None, metadata={"description": "Reference to the cluster ID"})
 
     def post_process(self, graph_builder: GraphBuilder, source: Json) -> None:
         def collect_fleets() -> None:
@@ -133,7 +132,7 @@ class AzureFleet(MicrosoftResource):
                     cluster_id = item["properties"]["clusterResourceId"]
                     graph_builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureManagedCluster, id=cluster_id)
                 except KeyError as e:
-                    log.warning(f"An error occured while setting cluster_resource_id: {e}")
+                    log.warning(f"An error occured while taking cluster id: {e}")
 
         graph_builder.submit_work(service, collect_fleets)
 


### PR DESCRIPTION
# Description
Fleet members can have different cluster references, allowing them to connect to various clusters instead of just one.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
