### PR TITLE
[core][fix] Do not use arangosearch for nested array context searches

### DIFF
--- a/fixcore/fixcore/db/arango_query.py
+++ b/fixcore/fixcore/db/arango_query.py
@@ -269,8 +269,13 @@ def query_view_string(
             # we filter the list down as much as possible, but leave the context term untouched
             is_array_context = bool(array_marker.search(term.name))
             context_in_array = context_in_array or is_array_context
-            sp, ct = view_term(term.predicate_term())
-            return sp, term if is_array_context else ct
+            # arangosearch view does not handle nested array searches correctly
+            # see: https://github.com/arangodb/arangodb/issues/21281
+            # once this is resolved we can enable the next 3 lines
+            #
+            # sp, ct = view_term(term.predicate_term())
+            # return sp, term if is_array_context else ct
+            return (None, term) if is_array_context else view_term(term.predicate_term())
         elif isinstance(term, IdTerm):
             if len(term.ids) == 1:
                 sp = f"{crs}._key == @{ctx.add_bind_var(term.ids[0])}"

--- a/fixcore/fixcore/db/arango_query.py
+++ b/fixcore/fixcore/db/arango_query.py
@@ -263,7 +263,8 @@ def query_view_string(
             return (None, term) if sp is None else (sp, evolve(term, pre_filter=pre))
         elif isinstance(term, NotTerm):
             sp, nt = view_term(term.term)
-            return (None, term) if sp is None else (f"NOT ({sp})", NotTerm(nt))
+            remaining = nt if nt.is_all else NotTerm(nt)  # a remaining filter needs to be negated
+            return (None, term) if sp is None else (f"NOT ({sp})", remaining)
         elif isinstance(term, ContextTerm):
             # context terms cannot be handled by the view search exhaustively
             # we filter the list down as much as possible, but leave the context term untouched


### PR DESCRIPTION
# Description

The view only yields some results correctly when using nested array searches.
With this PR, the view is no longer used; it uses plain old filters instead.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
