### PR TITLE
[fixlib][feature] Add the source of resource kind

### DIFF
--- a/fixlib/fixlib/core/model_export.py
+++ b/fixlib/fixlib/core/model_export.py
@@ -137,6 +137,14 @@ def model_name(clazz: Union[type, Tuple[Any], None]) -> str:
         return "any"
 
 
+def model_source(module_name: str) -> Optional[str]:
+    if module_name.startswith("fix_plugin_"):  # Naming scheme for all fix plugins: fix_plugin_<source>.xxx
+        return module_name.split(".")[0][11:]
+    elif module_name.startswith("fixlib.baseresources"):  # All base kinds are defined in this package
+        return "base"
+    return None
+
+
 # define if a field should be exported or not.
 # Use python default: hide props starting with underscore.
 def should_export(field: Attribute) -> bool:  # type: ignore
@@ -267,6 +275,8 @@ def dataclasses_to_fixcore_model(
             and isinstance(s, str)
         ):
             metadata["description"] = s
+        if root and (source := model_source(clazz.__module__)):
+            metadata["source"] = source
 
         model.append(
             {

--- a/fixlib/test/core/model_export_test.py
+++ b/fixlib/test/core/model_export_test.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict, Union, ClassVar
 
 from attrs import define, field
 
-from fixlib.baseresources import ModelReference
+from fixlib.baseresources import ModelReference, BaseAccessKey
 from fixlib.core.model_export import (
     is_collection,
     type_arg,
@@ -14,6 +14,7 @@ from fixlib.core.model_export import (
     dataclasses_to_fixcore_model,
     model_name,
     dynamic_object_to_fixcore_model,
+    model_source,
 )
 
 
@@ -208,3 +209,11 @@ def test_config_export():
     # All global config properties are defined
     config = {a["name"] for a in result_dict["config"]["properties"]}
     assert config == {"aws", "gcp"}
+
+
+def test_module_source() -> None:
+    assert model_source(BaseAccessKey.__module__) == "base"
+    assert model_source(DataClassBase.__module__) is None
+    assert model_source("fix_plugin_aws.resource.sagemaker.AwsSagemakerAlgorithm") == "aws"
+    assert model_source("fix_plugin_digitalocean.resources.DigitalOceanApp") == "digitalocean"
+    assert model_source("fix_plugin_azure.resource.machinelearning.AzureMachineLearningCompute") == "azure"


### PR DESCRIPTION
# Description

Add a source attribute to the kind metadata section.
Example:
```json
[
    { "fqn": "resource", "metadata": { "source": "base" } },
    { "fqn": "instance", "metadata": { "source": "base" } }
    { "fqn": "aws_resource", "metadata": { "source": "aws" } },
    { "fqn": "aws_ec2_instance", "metadata": { "source": "aws" } }
]
```

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
