### PR TITLE
[azure][fix]: Ignore errors from Azure side

### DIFF
--- a/plugins/azure/fix_plugin_azure/resource/cosmosdb.py
+++ b/plugins/azure/fix_plugin_azure/resource/cosmosdb.py
@@ -2057,6 +2057,7 @@ class AzureCosmosDBLocation(CosmosDBLocationSetter, MicrosoftResource, PhantomBa
         query_parameters=["api-version"],
         access_path="value",
         expect_array=True,
+        expected_error_codes={"Internal Server Error": None},
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),

--- a/plugins/azure/fix_plugin_azure/resource/monitor.py
+++ b/plugins/azure/fix_plugin_azure/resource/monitor.py
@@ -391,6 +391,7 @@ class AzureMonitorAlertRule(MicrosoftResource):
         query_parameters=["api-version"],
         access_path="value",
         expect_array=True,
+        expected_error_codes={"InvalidResourceType": None},
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),

--- a/plugins/azure/fix_plugin_azure/resource/network.py
+++ b/plugins/azure/fix_plugin_azure/resource/network.py
@@ -6771,6 +6771,7 @@ class AzureNetworkDNSZone(MicrosoftResource, BaseDNSZone):
         query_parameters=["api-version"],
         access_path="value",
         expect_array=True,
+        expected_error_codes={"BadRequest": None},
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),

--- a/plugins/azure/fix_plugin_azure/resource/storage.py
+++ b/plugins/azure/fix_plugin_azure/resource/storage.py
@@ -204,6 +204,7 @@ class AzureStorageAccountDeleted(MicrosoftResource, PhantomBaseResource):
         query_parameters=["api-version"],
         access_path="value",
         expect_array=True,
+        expected_error_codes={"ProviderError": None},
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
@@ -1082,7 +1083,7 @@ class AzureStorageAccountUsage(MicrosoftResource, AzureBaseUsage):
         query_parameters=["api-version"],
         access_path="value",
         expect_array=True,
-        expected_error_codes=AzureBaseUsage._expected_error_codes,
+        expected_error_codes=AzureBaseUsage._expected_error_codes | {"SubscriptionNotFound": None},
     )
     mapping: ClassVar[Dict[str, Bender]] = AzureBaseUsage.mapping | {
         "id": S("name", "value"),


### PR DESCRIPTION
# Description
Azure may throw errors via API/cli for the following commands for no reason:
| API path | Corresponding error |
|----------|----------|
| `/subscriptions/{subscriptionId}/providers/Microsoft.Network/dnszones` | The specified subscription `{subID}` does not exist (`BadRequest`) |
| `/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations` | `subscriptionQuotaId` is null or empty or whitespace (`Internal Server Error`) |
| `/subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts` | Resource provider 'Microsoft.Storage' failed to return collection response for type 'deletedAccounts' (`ProviderError`) |
|`/subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/usages` | Subscription `{subID}` was not found. (`SubscriptionNotFound`) |
|`/subscriptions/{subscriptionId}/providers/Microsoft.Insights/alertrules`| The resource type could not be found in the namespace 'Microsoft.Insights' for api version '2016-03-01'." (`InvalidResourceType`)|
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
