### PR TITLE
[docs][fixlib] Fix some typos in doc-strings

### DIFF
--- a/fixlib/fixlib/config.py
+++ b/fixlib/fixlib/config.py
@@ -157,7 +157,7 @@ class Config(metaclass=MetaConfig):
                 if reload and self.restart_required(new_config):
                     restart()
 
-            # update the global config object with the confif from the core
+            # update the global config object with the config from the core
             Config.running_config.data = self.with_default_config(raw_config_json)
             # if the raw_config was not empty, we need to set the revision too
             if new_config_revision:

--- a/fixlib/fixlib/tree.py
+++ b/fixlib/fixlib/tree.py
@@ -878,7 +878,7 @@ class Tree(object):
         cn = self[nid]
         for attr, val in attrs.items():
             if attr == "identifier":
-                # Updating node id meets following contraints:
+                # Updating node id meets following constraints:
                 # * Update node identifier property
                 # * Update parent's followers
                 # * Update children's parents

--- a/fixlib/fixlib/utils.py
+++ b/fixlib/fixlib/utils.py
@@ -491,7 +491,7 @@ def merge_json_elements(
     merge_strategy: Callable[[JsonElement, JsonElement], JsonElement] = lambda existing_val, update_val: update_val,
 ) -> JsonElement:
     """
-    Merges two JsonElements accorting to merge strategy.
+    Merges two JsonElements according to merge strategy.
     By default recursively traverses Dicts and prefers the new value
     """
     if isinstance(existing, dict) and isinstance(update, dict):

--- a/fixlib/test/test_utils.py
+++ b/fixlib/test/test_utils.py
@@ -479,7 +479,7 @@ def test_freeze():
     # nested too
     nested_dict = {"foo": flat_dict}
     assert freeze(nested_dict) == frozendict({"foo": frozendict(flat_dict)})
-    # and a list to tupple
+    # and a list to tuple
     assert freeze([1, 2]) == (1, 2)
 
 


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->

This PR fixes some typos in [`fixlib`](https://github.com/someengineering/fixinventory/tree/main/fixlib). Similar to #2303.

I decided not to create an issue for such a small change. If you think it is needed, please let me know.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] ~I have created tests for any new or updated functionality.~ (not relevant)
- [x] I ran tox successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
