### PR TITLE
[plugins/k8s][style] Remove duplicated `pytest` import

### DIFF
--- a/plugins/k8s/test/resources_test.py
+++ b/plugins/k8s/test/resources_test.py
@@ -1,6 +1,3 @@
-# noinspection PyUnresolvedReferences
-import pytest
-
 from fixlib.json import from_json
 
 # noinspection PyUnresolvedReferences


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->
Another _typo-like-fix_: removes the duplicated `pytest` import.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] ~I have created tests for any new or updated functionality.~ (not relevant)
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
