### PR TITLE
[fix][chore] Bump `jinja2` to `3.1.5`

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -77,7 +77,7 @@ jaraco-collections==5.1.0
 jaraco-context==6.0.1
 jaraco-functools==4.1.0
 jaraco-text==4.0.0
-jinja2==3.1.4
+jinja2==3.1.5
 jmespath==1.0.1
 jq==1.8.0
 jsons==1.6.3

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -65,7 +65,7 @@ jaraco-collections==5.1.0
 jaraco-context==6.0.1
 jaraco-functools==4.1.0
 jaraco-text==4.0.0
-jinja2==3.1.4
+jinja2==3.1.5
 jmespath==1.0.1
 jq==1.8.0
 jsons==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ jaraco-collections==5.1.0
 jaraco-context==6.0.1
 jaraco-functools==4.1.0
 jaraco-text==4.0.0
-jinja2==3.1.4
+jinja2==3.1.5
 jmespath==1.0.1
 jq==1.8.0
 jsons==1.6.3


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->
Due to:
- GHSA-q2x7-8rv6-6q7h
- GHSA-gmj6-6f8f-6699

I suggest to update `jinja2` to [`3.1.5`](https://github.com/pallets/jinja/releases/tag/3.1.5).

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] I have created tests for any new or updated functionality.
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
