### PR TITLE
[style] Do not use `is` to compare literals

### DIFF
--- a/fixcore/tests/fixcore/model/model_test.py
+++ b/fixcore/tests/fixcore/model/model_test.py
@@ -104,7 +104,7 @@ def test_number() -> None:
     assert int32.coerce_if_required("no number") is None
     assert int32.check_valid(1) is None
     assert int32.check_valid(8) is None
-    assert int32.check_valid("8") is 8
+    assert int32.check_valid("8") == 8
     assert expect_error(int32, "7.123") == "Expected type int32 but got str"
     assert flot.check_valid("7.123") == 7.123
     assert expect_error(int32, 0) == ">0< should be greater or equals than: 1"

--- a/fixcore/tests/fixcore/util_test.py
+++ b/fixcore/tests/fixcore/util_test.py
@@ -43,14 +43,14 @@ def test_access_json() -> None:
     assert access.a == "a"
     assert access.b.d.f[2] == 2
     assert access.this == js
-    assert str(access.b.d.f[99]) is "null"
-    assert str(access.b.d.f["test"]) is "null"
-    assert str(access.foo.bla.bar[23].now) is "null"
+    assert str(access.b.d.f[99]) == "null"
+    assert str(access.b.d.f["test"]) == "null"
+    assert str(access.foo.bla.bar[23].now) == "null"
     assert json.dumps(access.b.d, sort_keys=True) == '{"e": "e", "f": [0, 1, 2, 3, 4]}'
 
     assert access["a"] == "a"
     assert access["b"]["d"]["f"][2] == 2
-    assert str(access["foo"]["bla"]["bar"][23]["now"]) is "null"
+    assert str(access["foo"]["bla"]["bar"][23]["now"]) == "null"
     assert json.dumps(access["b"]["d"], sort_keys=True) == '{"e": "e", "f": [0, 1, 2, 3, 4]}'
 
     assert [a for a in access] == ["a", "b"]

--- a/plugins/aws/fix_plugin_aws/resource/dynamodb.py
+++ b/plugins/aws/fix_plugin_aws/resource/dynamodb.py
@@ -607,7 +607,7 @@ class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource, HasResourcePolicy):
             builder.submit_work(service_name, add_instance, js)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if self.dynamodb_replication_group is not []:
+        if self.dynamodb_replication_group != []:
             for replica in self.dynamodb_replication_group:
                 if replica.kms_master_key_id:
                     builder.dependant_node(


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->
This PR makes the code conformant with [F632](https://docs.astral.sh/ruff/rules/is-literal/#is-literal-f632)/[R0123](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/literal-comparison.html).

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] ~I have created tests for any new or updated functionality.~ (not relevant)
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
