### PR TITLE
[style] Use `is` to compare types

### DIFF
--- a/fixcore/fixcore/model/typed_model.py
+++ b/fixcore/fixcore/model/typed_model.py
@@ -25,7 +25,7 @@ def type_fqn(tpe: type) -> str:
 
 
 def from_js(json: JsonElement, clazz: Type[AnyT]) -> AnyT:
-    return jsons.load(json, cls=clazz) if clazz != dict else json  # type: ignore
+    return jsons.load(json, cls=clazz) if clazz is not dict else json  # type: ignore
 
 
 def to_js(node: Any, **kwargs: Any) -> Json:

--- a/fixlib/test/core/model_export_test.py
+++ b/fixlib/test/core/model_export_test.py
@@ -83,8 +83,8 @@ def test_collection() -> None:
     assert is_collection(list) is True
     assert is_collection(dict) is False
 
-    assert type_arg(Optional[List[int]]) == int
-    assert type_arg(List[datetime]) == datetime
+    assert type_arg(Optional[List[int]]) is int
+    assert type_arg(List[datetime]) is datetime
 
 
 def test_dictionary() -> None:

--- a/plugins/azure/tools/azure_model_gen.py
+++ b/plugins/azure/tools/azure_model_gen.py
@@ -539,7 +539,7 @@ def path_set(obj, path, value, **options):
         while len(seq) < index:
             seq.append(None)
 
-        if value_index_type == int:
+        if value_index_type is int:
             seq.append([])
         elif value_index_type is None:
             seq.append(None)


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->
This PR makes the code conformant with [E721](https://docs.astral.sh/ruff/rules/type-comparison/#type-comparison-e721).

Similar to #2314.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] ~I have created tests for any new or updated functionality.~ (not relevant)
- [x] I ran `tox` successfully.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
