### PR TITLE
Fix some AGPL references that were left after returning to Apache2 

### DIFF
--- a/fixcore/pyproject.toml
+++ b/fixcore/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/fixlib/pyproject.toml
+++ b/fixlib/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/fixmetrics/pyproject.toml
+++ b/fixmetrics/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/fixshell/pyproject.toml
+++ b/fixshell/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/aws/pyproject.toml
+++ b/plugins/aws/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/aws/tools/awspolicygen/setup.py
+++ b/plugins/aws/tools/awspolicygen/setup.py
@@ -34,7 +34,7 @@ setup(
         "Intended Audience :: System Administrators",
         "Intended Audience :: Information Technology",
         # License information
-        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+        "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
         # Supported python versions
         "Programming Language :: Python :: 3.12",
         # Supported OS's

--- a/plugins/azure/pyproject.toml
+++ b/plugins/azure/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/digitalocean/pyproject.toml
+++ b/plugins/digitalocean/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/dockerhub/pyproject.toml
+++ b/plugins/dockerhub/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/example_collector/pyproject.toml
+++ b/plugins/example_collector/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/gcp/pyproject.toml
+++ b/plugins/gcp/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/gcp/tools/gcppolicygen/setup.py
+++ b/plugins/gcp/tools/gcppolicygen/setup.py
@@ -34,7 +34,7 @@ setup(
         "Intended Audience :: System Administrators",
         "Intended Audience :: Information Technology",
         # License information
-        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+        "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
         # Supported python versions
         "Programming Language :: Python :: 3.12",
         # Supported OS's

--- a/plugins/github/pyproject.toml
+++ b/plugins/github/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/hetzner/pyproject.toml
+++ b/plugins/hetzner/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.11",
     # Supported OS's

--- a/plugins/k8s/pyproject.toml
+++ b/plugins/k8s/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/onelogin/pyproject.toml
+++ b/plugins/onelogin/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/posthog/pyproject.toml
+++ b/plugins/posthog/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/random/pyproject.toml
+++ b/plugins/random/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/scarf/pyproject.toml
+++ b/plugins/scarf/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's

--- a/plugins/slack/pyproject.toml
+++ b/plugins/slack/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Intended Audience :: Information Technology",
     # License information
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (Apache-2.0+)",
+    "License :: OSI Approved :: Apache License 2.0 (Apache-2.0+)",
     # Supported python versions
     "Programming Language :: Python :: 3.12",
     # Supported OS's


### PR DESCRIPTION
Just to make the intention clear although License classifiers are deprecated...